### PR TITLE
Prevent exceptions from "Onliners" when using a fresh new User table

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -80,7 +80,11 @@ class HomeController extends Controller {
             ->get();
 
         // Onliners section
-        $onliners = User::with([])->orderBy('last_access_time', 'desc')->take(7)->get();
+        $onliners = User::with([])
+            ->whereNotNull('last_access_time')
+            ->orderBy('last_access_time', 'desc')
+            ->take(7)
+            ->get();
 
         $user_votes = [];
         $user_polls = [];


### PR DESCRIPTION
The User table's last_access_time column is nullable. When installing TWHL locally for development, example users are created with last_access_time=NULL. Combined with the front page's Onliners section, it results in this error message:

> Call to a member function diffForHumans() on null (View: E:\Programmering\twhl\resources\views\home\index.blade.php)
> (2/2) ErrorException

Alternative solution: change the example data to have non-NULL values for last_access_time. However that feels like a dirty solution to me. Code that handles potentially-null values should handle null values gracefully.