### PR TITLE
Fix sort_by in the API

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -920,7 +920,7 @@ class ApiController extends Controller {
                 if (!is_array($sort)) $sort = [$sort];
                 $s = Request::input('sort_by');
                 if ($s && isset($desc['allowed_sort_columns']) && array_search($s, $desc['allowed_sort_columns']) !== false) {
-                    $sort = array_merge($s, $sort);
+                    $sort = array_merge([$s], $sort);
                 }
 
                 $sort_desc = isset($desc['sort_descending']) ? $desc['sort_descending'] : false;


### PR DESCRIPTION
array_merge expects arrays, but gets a string. That's why https://twhl.info/api/vault-items?sort_by=updated_at is failing