### PR TITLE
API: Include User's last_access_time & last_login_time

### DIFF
--- a/app/Models/Accounts/User.php
+++ b/app/Models/Accounts/User.php
@@ -30,8 +30,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         'skill_map', 'skill_model', 'skill_code', 'skill_music', 'skill_voice', 'skill_animate', 'skill_texture'
     ];
 	protected $hidden = ['password', 'remember_token'];
-    public $visible = [ 'id', 'name', 'avatar_custom', 'avatar_file', 'title_custom', 'title_text', 'avatar_full', 'avatar_small', 'avatar_inline' ];
-    protected $dates = ['deleted_at', 'last_login_time', 'last_access_time'];
+    public $visible = [ 'id', 'name', 'avatar_custom', 'avatar_file', 'title_custom', 'title_text', 'avatar_full', 'avatar_small', 'avatar_inline', 'last_login_time', 'last_access_time' ];
+    public $dates = ['deleted_at', 'last_login_time', 'last_access_time'];
     protected $attributes = [ 'avatar_file' => 'user_noavatar1.png' ];
 
     protected $appends = ['avatar_full', 'avatar_small', 'avatar_inline', 'info_birthday_formatted'];


### PR DESCRIPTION
This makes the API include last_access_time and last_login_time in User objects. This would be useful data for the script I am working on, since I can give less attention to the maps of users who haven't been active for a long time.

At first I though this change could have a negative effect on database query result caching, since the timestamps change very often but the other columns don't. However, it looks like the framework is already building SELECT * queries so it shouldn't impact database performance, only the size of the HTTP response to the API client is negatively affected (by about 15-20% increase in response size for /api/users when I tested locally).

Regarding making $dates public: in ApiController::getDefinitions you check $obj->dates to help determine if a column should have the "date-time" format. However, it's always null since $dates is protected on all classes. By making $dates public, the check works and the date columns are correctly assigned the "date-time" format. Maybe this change should me made for the other objects with dates?