### PR TITLE
Add Docker images for PHP, MySQL & Node. Also bugfixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=You need to run `php artisan key:generate` to fix this.
+# You need to run `php artisan key:generate` which generates an APP_KEY.
+APP_KEY=
 APP_URL=http://localhost:82
 
 DB_HOST=localhost

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text=auto
+* text=auto eol=lf
 *.css linguist-vendored
 *.less linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/vendor
-/node_modules
 /.idea
+/docker-for-development/mysql-data
+/node_modules
+/vendor
 .env
 composer.phar

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,17 +13,17 @@ class DatabaseSeeder extends Seeder {
 	{
 		Model::unguard();
 
-        $this->call('DeleteEverythingSeeder');
-        $this->call('UserTableSeeder');
-        $this->call('WikiTableSeeder');
-        $this->call('VaultTableSeeder');
-        $this->call('ShoutTableSeeder');
-        $this->call('PollTableSeeder');
-        $this->call('NewsTableSeeder');
-        $this->call('MessageTableSeeder');
-        $this->call('ForumTableSeeder');
-        $this->call('JournalTableSeeder');
-        $this->call('CompetitionTableSeeder');
+        $this->call(\Database\Seeders\DeleteEverythingSeeder::class);
+        $this->call(\Database\Seeders\UserTableSeeder::class);
+        $this->call(\Database\Seeders\WikiTableSeeder::class);
+        $this->call(\Database\Seeders\VaultTableSeeder::class);
+        $this->call(\Database\Seeders\ShoutTableSeeder::class);
+        $this->call(\Database\Seeders\PollTableSeeder::class);
+        $this->call(\Database\Seeders\NewsTableSeeder::class);
+        $this->call(\Database\Seeders\MessageTableSeeder::class);
+        $this->call(\Database\Seeders\ForumTableSeeder::class);
+        $this->call(\Database\Seeders\JournalTableSeeder::class);
+        $this->call(\Database\Seeders\CompetitionTableSeeder::class);
 	}
 
 }

--- a/database/seeders/DeleteEverythingSeeder.php
+++ b/database/seeders/DeleteEverythingSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use DB;
+
 class DeleteEverythingSeeder extends \Illuminate\Database\Seeder
 {
 

--- a/docker-for-development/docker-compose.yaml
+++ b/docker-for-development/docker-compose.yaml
@@ -1,0 +1,37 @@
+name: twhl-dev
+services:
+  db:
+    container_name: twhl-dev-mysql
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_DATABASE=twhl
+      - MYSQL_ROOT_PASSWORD=cs_canbunk2
+    image: mysql:8.0
+#    ports:
+#      - "3306:3306"
+    volumes:
+      - ./mysql-data:/var/lib/mysql
+  node:
+    container_name: twhl-dev-node
+    build:
+      context: ./node
+    image: twhl-dev/node
+    volumes:
+       - ../:/var/twhl
+  php-apache:
+    build:
+      context: ./php-apache
+    container_name: twhl-dev-php-apache
+    environment:
+      - DB_DATABASE=twhl
+      - DB_HOST=twhl-mysql-db
+      - DB_PASSWORD=cs_canbunk2
+      - DB_USER=root
+    image: twhl-dev/php-apache
+    links:
+      - "db:twhl-mysql-db"
+    ports:
+      - "82:80"
+    volumes:
+      - ../:/var/www/html/twhl
+      - ./php-apache/twhl-dev-php-conf.d:/usr/local/etc/php/conf.d

--- a/docker-for-development/node/Dockerfile
+++ b/docker-for-development/node/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:19
+
+WORKDIR /var/twhl

--- a/docker-for-development/php-apache/Dockerfile
+++ b/docker-for-development/php-apache/Dockerfile
@@ -1,0 +1,44 @@
+FROM php:8.2-apache
+
+# Use the PHP development config
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+# Install PHP extensions
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions gd pdo_mysql @composer
+
+# Set the document root
+ENV APACHE_DOCUMENT_ROOT /var/www/html/twhl/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Apache listens on TCP port 80, so expose that
+EXPOSE 80/tcp
+
+# If we wanted to store the PHP files etc. in a volume:
+# VOLUME /var/www/html/twhl
+
+# Environment variables
+ENV DB_DATABASE=twhl
+ENV DB_HOST=twhl-mysql-db
+ENV DB_PASSWORD=cs_canbunk2
+ENV DB_USER=root
+
+# Script for waiting for the MySQL server to start
+COPY ./wait-for-mysql-to-start.php /usr/local/bin/wait-for-mysql-to-start
+RUN chmod +x /usr/local/bin/wait-for-mysql-to-start
+
+# Script for creating a .env file and running Composer
+COPY ./twhl-install.sh /usr/local/bin/twhl-install
+RUN chmod +x /usr/local/bin/twhl-install
+
+# This is where the good stuff goes, so make that the working directory
+WORKDIR /var/www/html/twhl/
+
+# Startup script
+COPY ./entrypoint.sh ../entrypoint.sh
+RUN chmod +x ../entrypoint.sh
+ENTRYPOINT "../entrypoint.sh"

--- a/docker-for-development/php-apache/entrypoint.sh
+++ b/docker-for-development/php-apache/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ ! -d ./vendor ] || [ ! -f ./.env ]
+then
+  echo "Running 'twhl-install'."
+  twhl-install
+else
+  echo "Remember to run 'composer install' or 'twhl-install' to install dependencies after pulling or changing branch."
+fi
+
+
+wait-for-mysql-to-start
+php artisan migrate:status | grep -q "Migration table not found"
+if [ $? == 0 ]
+then
+  echo "Did not find a migration table in the database."
+  echo "Running 'php artisan migrate --seed'."
+  echo "If it fails, you may have to rerun it manually."
+  php artisan migrate --seed
+fi
+
+echo "Running 'docker-php-entrypoint'"
+docker-php-entrypoint "apache2-foreground"

--- a/docker-for-development/php-apache/twhl-dev-php-conf.d/twhl.ini
+++ b/docker-for-development/php-apache/twhl-dev-php-conf.d/twhl.ini
@@ -1,0 +1,2 @@
+extension = gd
+extension = pdo_mysql

--- a/docker-for-development/php-apache/twhl-install.sh
+++ b/docker-for-development/php-apache/twhl-install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Running 'composer install'"
+composer install
+
+if [ ! -f ./.env ]
+then
+  echo "You do not have an '.env'. file yet."
+  echo "Copying '.env.example' to '.env'."
+  cp ./.env.example ./.env
+  echo "Replacing database connection details in .env."
+  sed -i "s/DB_DATABASE=.*/DB_DATABASE=${DB_DATABASE}/g" ./.env
+  sed -i "s/DB_HOST=.*/DB_HOST=${DB_HOST}/g" ./.env
+  sed -i "s/DB_PASSWORD=.*/DB_PASSWORD=${DB_PASSWORD}/g" ./.env
+  sed -i "s/DB_USER=.*/DB_USER=${DB_USER}/g" ./.env
+  echo "Running 'php artisan key:generate'."
+  php artisan key:generate
+else
+  echo "You have an .env file. Good."
+fi

--- a/docker-for-development/php-apache/wait-for-mysql-to-start.php
+++ b/docker-for-development/php-apache/wait-for-mysql-to-start.php
@@ -1,0 +1,28 @@
+#!/usr/local/bin/php
+<?php
+$dbDatabase = getenv("DB_DATABASE");
+$dbHost = getenv("DB_HOST");
+$dbPassword = getenv("DB_PASSWORD");
+$dbUser = getenv("DB_USER");
+
+$connectionAttempts = 0;
+while (true) {
+    $connectionAttempts++;
+    try {
+        new PDO("mysql:dbname=" . $dbDatabase . ";host=" . $dbHost, $dbUser, $dbPassword);
+        echo "The MySQL server can be reached.\n";
+        exit(0);
+    }
+    catch (PDOException $error) {
+        if ($connectionAttempts > 30) {   
+            echo "Failed to connect to the MySQL server. Giving up.\n";
+            var_dump($error);
+            exit(1);
+        }
+    }
+    $delay = ceil($connectionAttempts * 0.5);
+    echo "Failed to connect to the MySQL server. Retrying in " . $delay . " seconds. The server is probably still starting up.\n";
+    sleep($delay);
+}
+
+?>

--- a/docker-for-development/readme.md
+++ b/docker-for-development/readme.md
@@ -1,0 +1,29 @@
+Delete your `.env` file if you have one and run this in Bash or PowerShell to build the Docker images and start the containers:
+```
+docker compose up
+```
+
+To install the Composer dependencies and create the `.env` file (if it does not exist), run:
+```
+docker compose exec php-apache twhl-install
+```
+
+To run `npm install` inside the Node container:
+```
+docker compose run node npm install
+```
+
+To start a Bash instance inside the PHP & Apache container for executing commands, run this:
+```
+docker compose exec php-apache bash
+```
+
+To see the Apache log, run this:
+```
+docker compose logs php-apache
+```
+
+To rebuild the images:
+```
+docker compose build
+```

--- a/docker-for-development/readme.md
+++ b/docker-for-development/readme.md
@@ -2,6 +2,7 @@ Delete your `.env` file if you have one and run this in Bash or PowerShell to bu
 ```
 docker compose up
 ```
+The web server can then be reached at http://localhost:82 .
 
 To install the Composer dependencies and create the `.env` file (if it does not exist), run:
 ```

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,8 @@ TWHL is a mapping and modding resource website for the Half-Life and Source engi
 TWHL4 uses the [Laravel](http://laravel.com/) framework. Detailed instructions can be found
 in the Laravel docs, but here's the basic steps:
 
-1. Get an Apache environment with MySQL (5.5+) and PHP (7.3+)
+0. If you know how to use Docker, see the [docker-for-development](docker-for-development/readme.md) folder and skip many of the following steps.
+1. Get an Apache environment with MySQL (5.5+) and PHP (8+)
    - The easiest way to do this is to download [XAMPP](https://www.apachefriends.org/index.html)
    for your platform and follow the install instructions.
    - Put the **php**/**php.exe** executable path into your system's environment variables

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -127,7 +127,7 @@
                         <li><a href="{{ act('wiki', 'page', \App\Models\Wiki\WikiRevision::CreateSlug('category:Entity Guides')) }}"><span class="fa fa-info-circle"></span> Entity Guides</a></li>
                     </ul>
 <?php
-                    $wiki_spotlight = $wiki_articles['featured_tutorials'][0];
+                    $wiki_spotlight = count($wiki_articles['featured_tutorials']) > 0 ? $wiki_articles['featured_tutorials'][0] : null;
 ?>
                     @if ($wiki_spotlight)
                         <div class="text-center">


### PR DESCRIPTION
Hi! Setting up PHP & Apache can be really painful, especially on Windows. With these Docker files you get a MySQL server with a database, Apache configured for PHP, PHP with the necessary extensions, and Node. Since it's Docker, running these doesn't leave a mess of different versions of software on your system and it's easy to change versions.

If you want to try it out, you might have to convert the line endings for the files in docker-for-development (this is only necessary once, the .gitattributes change would make sure we get Linux-compatible line endings in the future).

These Docker images could make it easier for others to contribute code