### PR TITLE
API spec: add schemes, more precise parameter types

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -281,8 +281,18 @@ class ApiController extends Controller {
                     'method' => 'post',
                     'operationId' => 'pageInformationPost',
                     'parameters' => [
-                        'pages' => [ 'required' => true, 'type' => 'array', 'description' => 'The list of page slugs to check' ],
-                        'embeds' => [ 'required' => true, 'type' => 'array', 'description' => 'The list of embed slugs to check' ]
+                        'pages' => [
+                            'required' => true,
+                            'type' => 'array',
+                            'items' => [ 'type' => 'string' ],
+                            'description' => 'The list of page slugs to check'
+                        ],
+                        'embeds' => [
+                            'required' => true,
+                            'type' => 'array',
+                            'items' => [ 'type' => 'string' ],
+                            'description' => 'The list of embed slugs to check'
+                        ]
                     ],
                     'response' => [
                         'description' => 'Page information',
@@ -875,6 +885,7 @@ class ApiController extends Controller {
             ],
             'paths' => $api_desc,
             'host' => preg_replace('%https?://([^/]*)/.*%', '\1', asset('/')),
+            'schemes' => [ preg_replace('%(https?):.*%', '\1', asset('/')) ],
             'basePath' => '/api',
             'definitions' => $this->getDefinitions(),
             'securityDefinitions' => [


### PR DESCRIPTION
* `pageInformationPost`'s parameters are arrays. The type of the elements was unspecified. This PR sets the type of those arrays' elements to `string` type.
* Set the [`schemes`](https://swagger.io/specification/v2/#:~:text=path%20templating.-,schemes,%5Bstring%5D,-The%20transfer%20protocol) property to `["https"]` or `["http"]`. Without this change, the default value ("the one used to access the Swagger definition itself") could be incorrect for copies of the spec.