### PR TITLE
MySQL in Docker: Use utf8mb4_unicode_ci

### DIFF
--- a/docker-for-development/docker-compose.yaml
+++ b/docker-for-development/docker-compose.yaml
@@ -1,6 +1,8 @@
 name: twhl-dev
 services:
   db:
+    command:
+      --collation-server=utf8mb4_unicode_ci
     container_name: twhl-dev-mysql
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
Some version of MySQL started using utf8mb4_0900_ai_ci by default instead of utf8mb4_unicode_ci which breaks some stored procedures if the TWHL database was created using the now default collation