### PR TITLE
Fix error when pasting GIFs

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -1420,7 +1420,7 @@ class ApiController extends Controller {
         });
 
         $this->validate(Request::instance(), [
-            'image' => 'required|max:2048|valid_extension:jpeg,jpg,png|image_size:3000'
+            'image' => 'required|max:2048|valid_extension:gif,jpeg,jpg,png|image_size:3000'
         ], [
             'image_size' => 'The image cannot have a width or height of more than 3000 pixels',
         ]);


### PR DESCRIPTION
GIF isn't the best format, but the JS paste code allows GIFs so the PHP upload code must support it too or the user gets an error message "[img:Error: validation.valid_extension]" when pasting GIFs