### PR TITLE
Remove /index suffixes from links

### DIFF
--- a/app/Helpers/ViewFunctions.php
+++ b/app/Helpers/ViewFunctions.php
@@ -28,7 +28,11 @@ if (!function_exists('act'))
             if (!is_array($arg)) $arr[] = $arg;
             else foreach ($arg as $k => $v) $arr[$k] = $v;
         }
-        return url($controller.'/'.$action, $arr);
+        $path = $controller;
+        if ($action !== 'index') {
+            $path .= '/' . $action;
+        }
+        return url($path, $arr);
     }
 }
 


### PR DESCRIPTION
Crosses off point 3 of #76. Removes the "/index" from links such as "/vault/index" and "/forum/index" 