### PR TITLE
Remove "0" and "0.5" rating filter options

### DIFF
--- a/resources/views/vault/list.blade.php
+++ b/resources/views/vault/list.blade.php
@@ -68,8 +68,7 @@
                 <li class="filter-action" data-filter-value="2">2</li>
                 <li class="filter-action" data-filter-value="1.5">1.5</li>
                 <li class="filter-action" data-filter-value="1">1</li>
-                <li class="filter-action" data-filter-value="0.5">0.5</li>
-                <li class="filter-action" data-filter-value="0">0</li>
+                <li class="clear-filter static-control filter-action"><span class="fa fa-remove"></span> Clear Filter</li>
             </ul>
             <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown"><span class="filter-info">Sort: Created</span></button>
             <ul class="dropdown-menu pull-right vault-filter filter-one filter-sort">


### PR DESCRIPTION
Crosses off point 13 of https://github.com/LogicAndTrick/twhl/issues/76. Replaces 0 and 0.5 (which are impossible ratings)
<img width="236" height="438" alt="Screenshot 2026-02-02 at 13 19 14" src="https://github.com/user-attachments/assets/fee9e5c6-9612-4c33-8aa1-23200e53aa1f" />
with a Clear Filter button
<img width="236" height="401" alt="Screenshot 2026-02-02 at 13 18 52" src="https://github.com/user-attachments/assets/860e03bc-4545-4780-8d8e-77a7761ca92d" />
