### PR TITLE
Fix bug: "Sort: Created" becoming "Sort: Date" after changing any of the Vault filters

### DIFF
--- a/resources/views/vault/list.blade.php
+++ b/resources/views/vault/list.blade.php
@@ -156,7 +156,7 @@
 
         function update_filters(cls) {
             const classes = ['filter-games', 'filter-categories', 'filter-types', 'filter-users', 'filter-includes', 'filter-rating', 'filter-sort'];
-            const zero = ['All Games', 'All Categories', 'All Types', 'All Users', 'Any Includes', 'Min. Rating: Any', 'Sort: Date'];
+            const zero = ['All Games', 'All Categories', 'All Types', 'All Users', 'Any Includes', 'Min. Rating: Any', 'Sort: Created'];
             const one = ['{text}', '{text}', '{text}', '<img src="{avatar}" alt="avatar" /> {text}', '{text}', 'Min. Rating: {text}', 'Sort: {text}'];
             const many = ['{count} Games', '{count} Categories', '{count} Types', '{count} Users', '{count} Includes', 'Min. Rating: {text}', 'Sort: {text}'];
 


### PR DESCRIPTION
Without this fix, when you change any of the filters, the text "Sort: Created" turns into "Sort: Date" when you make any change to the filters. "Date" is not one of the sort options.

<img width="498" height="88" alt="Screenshot 2026-02-02 at 13 24 26" src="https://github.com/user-attachments/assets/691eb1d5-49a2-4860-8941-6d6096429007" />
<img width="498" height="88" alt="Screenshot 2026-02-02 at 13 24 32" src="https://github.com/user-attachments/assets/520ce9f7-6006-426a-8923-a9d103602e82" />
