### PR TITLE
Update wiki object in transaction

### DIFF
--- a/database/migrations/2026_02_16_195724_wiki_revision_fix.php
+++ b/database/migrations/2026_02_16_195724_wiki_revision_fix.php
@@ -10,6 +10,9 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // See https://github.com/LogicAndTrick/twhl/issues/133
+
+        
         DB::unprepared("DROP procedure IF EXISTS update_wiki_object;");
         DB::unprepared("
             CREATE PROCEDURE update_wiki_object(oid INT)

--- a/database/migrations/2026_02_16_211818_fix_broken_wiki_objects.php
+++ b/database/migrations/2026_02_16_211818_fix_broken_wiki_objects.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // See https://github.com/LogicAndTrick/twhl/issues/133
+
+        $brokenObjects = DB::select("SELECT obj.id AS id FROM wiki_objects AS obj INNER JOIN wiki_revisions AS rev ON obj.current_revision_id=rev.id WHERE rev.is_active=0 AND obj.deleted_at IS NULL");
+
+        foreach ($brokenObjects as $bo) {
+            $id = $bo->id;
+            DB::statement('CALL update_wiki_object(?);', [$id]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Fixes #133 

Makes ALL or NONE of the updates in a transaction succeed, with no partial failures.

Includes a migration to fix any already broken wiki page