### PR TITLE
Fixes for the new wiki_revisions_update_statistics_on_update

### DIFF
--- a/database/migrations/2026_02_16_223640_fix_wiki_stats_update.php
+++ b/database/migrations/2026_02_16_223640_fix_wiki_stats_update.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared("DROP TRIGGER IF EXISTS wiki_revisions_update_statistics_on_update;");
+        DB::unprepared("
+            CREATE TRIGGER wiki_revisions_update_statistics_on_update AFTER UPDATE ON wiki_revisions
+            FOR EACH ROW BEGIN
+                IF COALESCE(@disable_wiki_revisions_update_statistics_on_update, 0) != 1 THEN
+                    CALL update_user_wiki_statistics(NEW.user_id);
+    
+                    IF NEW.user_id != OLD.user_id THEN
+                        CALL update_user_wiki_statistics(OLD.user_id);
+                    END IF;
+                END IF;
+            END;");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared("DROP TRIGGER IF EXISTS wiki_revisions_update_statistics_on_update;");
+        DB::unprepared("
+            CREATE TRIGGER wiki_revisions_update_statistics_on_update AFTER UPDATE ON wiki_revisions
+            FOR EACH ROW BEGIN
+                IF @disable_wiki_revisions_update_statistics_on_update != 1 THEN
+                    CALL update_user_wiki_statistics(NEW.user_id);
+    
+                    IF NEW.user_id != OLD.user_id THEN
+                        CALL update_user_wiki_statistics(OLD.user_id);
+                    END IF;
+                END IF;
+            END;");
+    }
+};


### PR DESCRIPTION
Fixes a couple of bugs in https://github.com/LogicAndTrick/twhl/commit/25a20f2316d0a27dfcbe203158ced9f0bd7a9ffe related to issue #133 

- DeployFormat.php was replacing the updated procedure with the old one
- The `IF` statement wasn't doing anything because `NULL != 1` is `NULL` in MySQL but we need it to behave the same as `0 != 1` (which is `1`)