### PR TITLE
Cut UTF-8 strings correctly

### DIFF
--- a/app/Console/Commands/FormatWiki.php
+++ b/app/Console/Commands/FormatWiki.php
@@ -46,8 +46,8 @@ class FormatWiki extends Command
             /** @var WikiRevision $rev */
             foreach ($revisions as $rev ) {
 
-                $trim_title = substr($rev->title, 0, 50);
-                if (strlen($rev->title) > strlen($trim_title)) $trim_title = substr($trim_title, 0, 47) . '...';
+                $trim_title = mb_substr($rev->title, 0, 50);
+                if (mb_strlen($rev->title) > mb_strlen($trim_title)) $trim_title = mb_substr($trim_title, 0, 47) . '...';
                 $this->getOutput()->write("\r[$current/$total] Revision #{$rev->id} ($trim_title)");
                 $current++;
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -7,8 +7,8 @@
         <title>{{ isset($page_title) && !!$page_title ? $page_title . ' - ' : '' }}TWHL: Half-Life and Source Mapping Tutorials and Resources</title>
 
         <meta content="The Whole Half-Life" property="og:site_name">
-        @if (isset($meta_description) && strlen($meta_description) > 0)
-            <?php $meta_description = str_replace("\n", ' ', substr($meta_description, 0, 300)) . (strlen($meta_description) > 300 ? '...' : ''); ?>
+        @if (!empty($meta_description))
+            <?php $meta_description = str_replace("\n", ' ', mb_substr($meta_description, 0, 300)) . (mb_strlen($meta_description) > 300 ? '...' : ''); ?>
             <meta property="og:description" content="{{$meta_description}}">
         @else
             <meta property="og:description" content="View this page on TWHL">

--- a/resources/views/wiki/special/query-search.blade.php
+++ b/resources/views/wiki/special/query-search.blade.php
@@ -35,16 +35,18 @@
                 <a href="{{ url('wiki/page/' . $page->slug) }}">{{$page->title}}</a>
                 <?php
                     $pos = 0;
+                    $search_length = mb_strlen($search);
                     while ($pos !== false) {
-                        $idx = stripos($page->content_text, $search, $pos);
+                        $idx = mb_stripos($page->content_text, $search, $pos);
                         if ($idx === false) break;
 
+                        $content_length = mb_strlen($page->content_text);
                         $st = max(0, $idx - 50);
-                        $en = min(strlen($page->content_text), $idx + strlen($search) + 50);
+                        $en = min($content_length, $idx + $search_length + 50);
                         echo '<br>';
-                        echo '<span class="text-muted">' . ($st > 0 ? '...' : '') . substr($page->content_text, $st, $idx - $st) . '</span>';
-                        echo '<strong>' . substr($page->content_text, $idx, strlen($search)) . '</strong>';
-                        echo '<span class="text-muted">' . substr($page->content_text, $idx + strlen($search), $en - ($idx + strlen($search))) . ($en < strlen($page->content_text) ? '...' : '') . '</span>';
+                        echo '<span class="text-muted">' . ($st > 0 ? '...' : '') . mb_substr($page->content_text, $st, $idx - $st) . '</span>';
+                        echo '<strong>' . mb_substr($page->content_text, $idx, $search_length) . '</strong>';
+                        echo '<span class="text-muted">' . mb_substr($page->content_text, $idx + $search_length, $en - ($idx + $search_length)) . ($en < $content_length ? '...' : '') . '</span>';
 
                         $pos = $idx + 1;
                     }


### PR DESCRIPTION
Fixes #138 
UTF-8 strings are sometimes being cut in the middle of code points when strings contain multi-byte characters such as 🐿️ or ö. The broken strings are ugly and could prevent apps from parsing the Open Graph meta tags.

Without this fix:
<img width="548" height="411" alt="Screenshot 2026-02-17 at 23 46 46" src="https://github.com/user-attachments/assets/8dfe708c-1373-45b0-8024-6ea6e017ae41" />
With this fix:
<img width="548" height="411" alt="Screenshot 2026-02-17 at 23 47 32" src="https://github.com/user-attachments/assets/d481463a-0a17-48bf-86c4-6169027e45ef" />
