### PR TITLE
Prevent failure in 2026_02_08_020610_better_game_name_filtering.php

### DIFF
--- a/database/migrations/2026_02_08_020610_better_game_name_filtering.php
+++ b/database/migrations/2026_02_08_020610_better_game_name_filtering.php
@@ -27,13 +27,16 @@ class BetterGameNameFiltering extends Migration
             'Day of Defeat: Source' => 'DoD Source',
             'Garry\'s Mod' => 'Garrys Mod, Gary\'s Mod, Garys Mod',
             'Not Listed (Goldsource)' => 'GoldSrc, Gold Src, GoldSource, Gold Source',
+            'Not Listed (HL1 Engine)' => 'GoldSrc, Gold Src, GoldSource, Gold Source',
             'Spirit of Half-Life' => 'SoHL'
         ];
 
         foreach ($altNames as $name => $name_variants) {
-            $game = Game::query()->where('name', '=', $name)->firstOrFail();
-            $game->name_variants = $name_variants;
-            $game->save();
+            $game = Game::query()->where('name', '=', $name)->first();
+            if($game) {
+                $game->name_variants = $name_variants;
+                $game->save();
+            }
         }
 
     }


### PR DESCRIPTION
A fix to allow the migrations to complete when installing TWHL locally.

When installing TWHL from scratch, 2026_02_08_020610_better_game_name_filtering.php is failing because while TWHL.info's DB has the Game "Not Listed (Goldsource)", locally that Game is called "Not Listed (HL1 Engine)" as there is no migration file renaming "Not Listed (HL1 Engine)" to "Not Listed (Goldsource)".
